### PR TITLE
Relative path fix

### DIFF
--- a/cert_tools/create_certificate_template.py
+++ b/cert_tools/create_certificate_template.py
@@ -75,9 +75,7 @@ def additional_global_fields(config, raw_json):
 
 
 def create_certificate_section(config):
-    data_dir = config.data_dir
-    if not os.path.isabs(data_dir):
-        data_dir = os.path.join(os.getcwd(), data_dir)
+    data_dir = os.path.abspath(config.data_dir)
     cert_image_path = helpers.normalize_data_path(data_dir, config.cert_image_file)
     issuer_image_path = helpers.normalize_data_path(data_dir, config.issuer_logo_file)
     certificate = {
@@ -120,9 +118,7 @@ def create_recipient_section(config):
 
 
 def create_assertion_section(config):
-    data_dir = config.data_dir
-    if not os.path.isabs(data_dir):
-        data_dir = os.path.join(os.getcwd(), data_dir)
+    data_dir = os.path.abspath(config.data_dir)
     issuer_image_path = helpers.normalize_data_path(data_dir, config.issuer_signature_file)
     assertion = {
         'type': 'Assertion',
@@ -140,9 +136,7 @@ def create_certificate_template(config):
     assertion = create_assertion_section(config)
     recipient = create_recipient_section(config)
 
-    data_dir = config.data_dir
-    if not os.path.isabs(data_dir):
-        data_dir = os.path.join(os.getcwd(), data_dir)
+    data_dir = os.path.abspath(config.data_dir)
     template_dir = config.template_dir
     if not os.path.isabs(template_dir):
         template_dir = os.path.join(data_dir, template_dir)

--- a/cert_tools/create_certificate_template.py
+++ b/cert_tools/create_certificate_template.py
@@ -76,6 +76,8 @@ def additional_global_fields(config, raw_json):
 
 def create_certificate_section(config):
     data_dir = config.data_dir
+    if not os.path.isabs(data_dir):
+        data_dir = os.path.join(os.getcwd(), data_dir)
     cert_image_path = helpers.normalize_data_path(data_dir, config.cert_image_file)
     issuer_image_path = helpers.normalize_data_path(data_dir, config.issuer_logo_file)
     certificate = {
@@ -119,6 +121,8 @@ def create_recipient_section(config):
 
 def create_assertion_section(config):
     data_dir = config.data_dir
+    if not os.path.isabs(data_dir):
+        data_dir = os.path.join(os.getcwd(), data_dir)
     issuer_image_path = helpers.normalize_data_path(data_dir, config.issuer_signature_file)
     assertion = {
         'type': 'Assertion',
@@ -137,7 +141,11 @@ def create_certificate_template(config):
     recipient = create_recipient_section(config)
 
     data_dir = config.data_dir
+    if not os.path.isabs(data_dir):
+        data_dir = os.path.join(os.getcwd(), data_dir)
     template_dir = config.template_dir
+    if not os.path.isabs(template_dir):
+        template_dir = os.path.join(data_dir, template_dir)
     template_file_name = config.template_file_name
 
     raw_json = {


### PR DESCRIPTION
Fix relative paths specified in the config file not being converted into absolute paths using the correct root in some Linux systems.
Also fixed the template directory not being a sub-directory of the data directory. I may be wrong on this one, but the directory structure and the example conf.ini leaded me to this conclusion.