### PR TITLE
Added create_revocation_addresses.py script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,31 @@ It may also contain custom fields per-recipient. The create_certificate_template
 additional_per_recipient_fields = {"fields": [{"path": "$.recipient.revocationKey","value": "*|REVKEY|*","csv_column": "revkey"}]}
 ```
    
+### create_revocation_addresses.py
    
+#### Run (optional)
+```
+create-revocation-addresses -k tpubD6NzV...H66KUZEBkf
+```
+
+#### About
+
+Generates Bitcoin addresses using an HD extended public (or private) key to be used as the issuer's revocation addresses for the certificates. This would be useful only if the issuer requires to be able to revoke specific certificates later on. It creates a list of addresses that could then be easily merged with the roster file, e.g. using unix's paste command.
+
+To create 20 revocation address for a testnet extended public key for the first batch of 2016 certificates run:
+
+```
+echo "revkey" > rev_addresses.txt
+
+create-revocation-addresses -n 20 -p "2016/1" -k tpubD6NzV...H66KUZEBkf >> rev_addresses.txt
+```
+
+To merge to roster (in unix) run:
+
+```
+paste roster.txt rev_addresses.txt
+```
+
 ## Example
 
 See sample_data for example configuration and output. `conf-mainnet.ini` was used to create a batch of 2 unsigned certificates on the Bitcoin blockchain. 

--- a/cert_tools/create_revocation_addresses.py
+++ b/cert_tools/create_revocation_addresses.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env
+'''
+Generates Bitcoin addresses using an HD extended public key to be used as the issuer's revocation addresses for the certificates. 
+
+It creates a list of addresses that could then be easily merged with the roster file, e.g. using unix's paste command.
+'''
+import os
+import sys
+import configargparse
+from pycoin.key.BIP32Node import BIP32Node
+#from pycoin.encoding.EncodingError import EncodingError
+
+def generate_revocation_addresses(config):
+    key_path = config.key_path if config.key_path else ''
+    output_handle = open(config.output_file, 'w') if config.output_file else sys.stdout
+
+    try:
+        key = BIP32Node.from_text(config.extended_public_key)
+    except:
+        print('The extended public (or private) key seems invalid.')
+        sys.exit()
+    key_path_batch = key.subkey_for_path(key_path)
+    for i in range(config.number_of_addresses):
+        subkey = key_path_batch.subkey(i)
+        output_handle.write("{0}\n".format(subkey.address(1)))  # 1 for the internal keypair chain
+
+    if output_handle is not sys.stdout:
+        output_handle.close()
+
+def get_config():
+    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+    p = configargparse.getArgumentParser(default_config_files=[os.path.join(base_dir, 'conf.ini')]) 
+    p.add('-c', '--my-config', required=False, is_config_file=True, help='config file path')
+    p.add_argument('-k', '--extended_public_key', type=str, required=True, help='the HD extended public key used to generate the revocation addresses')
+    p.add_argument('-p', '--key_path', type=str, help='the key path used to derive the child key under which the addresses will be generated')
+    p.add_argument('-n', '--number_of_addresses', type=int, default=10, help='the number of revocation addresses to generate')
+    p.add_argument('-o', '--output_file', type=str, help='the output file to save the revocation addresses')
+    args, _ = p.parse_known_args()
+
+    return args
+
+
+def main():
+    conf = get_config()
+    generate_revocation_addresses(conf)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,6 @@ setup(
         'console_scripts': [
             'create-certificate-template = cert_tools.create_certificate_template:main',
             'instantiate-certificate-batch = cert_tools.instantiate_certificate_batch:main',
+            'create-revocation-addresses = cert_tools.create_revocation_addresses:main'
         ]}
 )


### PR DESCRIPTION
The script generates Bitcoin addresses using an HD extended public key to be used as the issuer's revocation addresses for the certificates. 

It creates a list of addresses that could then be easily merged with the roster file, e.g. using unix's paste command.

Currently, it assumes that you will provide the extended key yourself but we could easily add creation later on.