### PR TITLE
Use compressed addresses by default and minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,5 +101,4 @@ data/signed_certificates/*.json
 data/transaction_ids/*.txt
 data/receipts/*.json
 
-conf.ini
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ data/signed_certificates/*.json
 data/transaction_ids/*.txt
 data/receipts/*.json
 
+conf.ini
+.DS_Store

--- a/cert_tools/create_certificate_template.py
+++ b/cert_tools/create_certificate_template.py
@@ -120,13 +120,16 @@ def create_recipient_section(config):
 def create_assertion_section(config):
     data_dir = os.path.abspath(config.data_dir)
     issuer_image_path = helpers.normalize_data_path(data_dir, config.issuer_signature_file)
+
     assertion = {
         'type': 'Assertion',
         'issuedOn': '*|DATE|*',
-        'image:signature': helpers.encode_image(issuer_image_path),
         'uid': '*|CERTUID|*',
         'id': helpers.urljoin_wrapper(config.issuer_certs_url, '*|CERTUID|*')
     }
+    if config.issuer_signature_file:
+        issuer_image_path = helpers.normalize_data_path(data_dir, config.issuer_signature_file)
+        assertion['image:signature'] = helpers.encode_image(issuer_image_path)
     return assertion
 
 

--- a/cert_tools/create_revocation_addresses.py
+++ b/cert_tools/create_revocation_addresses.py
@@ -6,9 +6,10 @@ It creates a list of addresses that could then be easily merged with the roster 
 '''
 import os
 import sys
+
 import configargparse
 from pycoin.key.BIP32Node import BIP32Node
-#from pycoin.encoding.EncodingError import EncodingError
+
 
 def generate_revocation_addresses(config):
     key_path = config.key_path if config.key_path else ''
@@ -22,19 +23,25 @@ def generate_revocation_addresses(config):
     key_path_batch = key.subkey_for_path(key_path)
     for i in range(config.number_of_addresses):
         subkey = key_path_batch.subkey(i)
-        output_handle.write("{0}\n".format(subkey.address(1)))  # 1 for the internal keypair chain
+        output_handle.write("{0}\n".format(subkey.address(config.use_uncompressed)))
 
     if output_handle is not sys.stdout:
         output_handle.close()
 
+
 def get_config():
     base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
-    p = configargparse.getArgumentParser(default_config_files=[os.path.join(base_dir, 'conf.ini')]) 
+    p = configargparse.getArgumentParser(default_config_files=[os.path.join(base_dir, 'conf.ini')])
     p.add('-c', '--my-config', required=False, is_config_file=True, help='config file path')
-    p.add_argument('-k', '--extended_public_key', type=str, required=True, help='the HD extended public key used to generate the revocation addresses')
-    p.add_argument('-p', '--key_path', type=str, help='the key path used to derive the child key under which the addresses will be generated')
-    p.add_argument('-n', '--number_of_addresses', type=int, default=10, help='the number of revocation addresses to generate')
+    p.add_argument('-k', '--extended_public_key', type=str, required=True,
+                   help='the HD extended public key used to generate the revocation addresses')
+    p.add_argument('-p', '--key_path', type=str,
+                   help='the key path used to derive the child key under which the addresses will be generated')
+    p.add_argument('-n', '--number_of_addresses', type=int, default=10,
+                   help='the number of revocation addresses to generate')
     p.add_argument('-o', '--output_file', type=str, help='the output file to save the revocation addresses')
+    p.add_argument('-u', '--use_uncompressed', action='store_true', default=False,
+                   help='whether to use uncompressed bitcoin addresses')
     args, _ = p.parse_known_args()
 
     return args
@@ -47,4 +54,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/release_package.sh
+++ b/release_package.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+python setup.py register -r pypi
+python setup.py sdist upload -r pypi

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ bcrypt>=3.1.0
 jsonpath-rw>=1.4.0
 configargparse==0.10.0
 tox==2.3.1
+pycoin==0.70

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(here, 'README.md')) as fp:
 
 setup(
     name='cert-tools',
-    version='1.2.0',
+    version='1.2.1',
     description='creates blockchain certificates',
     author='MIT Media Lab Blockchain Certificates',
     tests_require=['tox'],


### PR DESCRIPTION
- Uncompressed addresses no longer default. Enable through configuration option.
- Add pycoin to requirements.txt -- needed by the revocation address script. 
- Fix for certificate template

/cc: @karask 