### PR TITLE
Fix setup.py to use v1 entry points

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ setup(
     include_package_data=True,
     entry_points={
         'console_scripts': [
-            'create-certificate-template = cert_tools.create_certificate_template:main',
-            'instantiate-certificate-batch = cert_tools.instantiate_certificate_batch:main',
+            'create-certificate-template = cert_tools.create_v1_2_certificate_template:main',
+            'instantiate-certificate-batch = cert_tools.instantiate_v1_2_certificate_batch:main',
             'create-revocation-addresses = cert_tools.create_revocation_addresses:main',
             'create-issuer = cert_tools.create_issuer:main'
         ]}


### PR DESCRIPTION
I tried to execute commands, but currently it doesn't work.
This is quick fix to use v1 entry points.