### PR TITLE
fixing duplication of ecdsa-koblitz-pubkey in batch creation

### DIFF
--- a/cert_tools/instantiate_v2_certificate_batch.py
+++ b/cert_tools/instantiate_v2_certificate_batch.py
@@ -59,7 +59,7 @@ def instantiate_recipient(config, cert, recipient):
     cert[profile_field] = {}
     cert[profile_field]['type'] = ['RecipientProfile', 'Extension']
     cert[profile_field]['name'] = recipient.name
-    cert[profile_field]['publicKey'] = 'ecdsa-koblitz-pubkey:' + recipient.pubkey
+    cert[profile_field]['publicKey'] = recipient.pubkey
 
     if config.additional_per_recipient_fields:
         if not recipient.additional_fields:


### PR DESCRIPTION
Before: 
```
"recipientProfile": {
        "publicKey": "ecdsa-koblitz-pubkey:ecdsa-koblitz pubkey:msBCHdwaQ7N2ypBYupkp6uNxtr9Pg76imj",
        "type": [
            "RecipientProfile",
            "Extension"
        ],
        "name": "Tim Chen"
    }
```
After:
```
"recipientProfile": {
        "publicKey": "ecdsa-koblitz pubkey:msBCHdwaQ7N2ypBYupkp6uNxtr9Pg76imj",
        "type": [
            "RecipientProfile",
            "Extension"
        ],
        "name": "Tim Chen"
    }
```