### PR TITLE
Fix the function create_iso8601_tz() in helpers.py

### DIFF
--- a/cert_tools/helpers.py
+++ b/cert_tools/helpers.py
@@ -2,7 +2,7 @@ import base64
 import json
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 import configargparse
 import pytz
@@ -57,6 +57,5 @@ def encode(num, alphabet=BASE62):
 
 
 def create_iso8601_tz():
-    tz = pytz.timezone('UTC')
-    aware_dt = tz.localize(datetime.now())
-    return aware_dt.isoformat()
+    ret = datetime.now(timezone.utc)
+    return ret.isoformat()


### PR DESCRIPTION
[This is a reposted pull request]

The origin version of this function will return the local time and "regard" it as the UTC time.

For example, I am in China and currently it's 2018-12-28, 02:03:08 (UTC+8), then the function will return 2018-12-28T02:03:08.278455+00:00. However, the correct result should be 2018-12-27T18:03:08.278455+00:00.

This directly results in the "Transaction occurred at time when issuing address was not considered valid" error in blockcerts.org. To be specific, if a certificate is issued within 8 hours the issuer file is created, it will be rejected by the website because the issuer file will REALLY take effective because the "created time" given by this function is actually 8 hours after the real created time.