### PR TITLE
fix iso format for v3

### DIFF
--- a/cert_tools/helpers.py
+++ b/cert_tools/helpers.py
@@ -57,5 +57,5 @@ def encode(num, alphabet=BASE62):
 
 
 def create_iso8601_tz():
-    ret = datetime.now(timezone.utc)
+    ret = datetime.now(timezone.utc).isoformat()[:-13]+'Z'
     return ret.isoformat()


### PR DESCRIPTION
To be able to verify the certification in V3, It is necessary to adjust the iso format to the method of validater in cert-issuer.

[https://github.com/blockchain-certificates/cert-issuer/blob/37399da56508dba073abea0f759b4157d0830cd5/cert_issuer/models.py#L7](url)