### PR TITLE
Fixed datetime method on str causing v2 failure

### DIFF
--- a/cert_tools/helpers.py
+++ b/cert_tools/helpers.py
@@ -57,5 +57,5 @@ def encode(num, alphabet=BASE62):
 
 
 def create_iso8601_tz():
-    ret = datetime.now(timezone.utc).isoformat()[:-13]+'Z'
-    return ret.isoformat()
+    ret = datetime.now(timezone.utc).isoformat()
+    return ret


### PR DESCRIPTION
It appears that a recent contribution was calling `isoformat` on a string. This caused my batch initiation to fail and may be a cause of the CI tests failing.