### PR TITLE
ISO8601 format

### DIFF
--- a/cert_tools/helpers.py
+++ b/cert_tools/helpers.py
@@ -57,5 +57,4 @@ def encode(num, alphabet=BASE62):
 
 
 def create_iso8601_tz():
-    ret = datetime.now(timezone.utc).isoformat()[:-13]+'Z'
-    return ret.isoformat()
+    return datetime.now(timezone.utc).isoformat()[:-13]+'Z'


### PR DESCRIPTION
As of this issue https://github.com/blockchain-certificates/cert-tools/issues/48
and the PR https://github.com/blockchain-certificates/cert-tools/pull/49 (paused for Python3 concerns)

I proposte this PR to only put the correct datetime format without any Python3  upgrade