### PR TITLE
prevent isoformat error

### DIFF
--- a/cert_tools/helpers.py
+++ b/cert_tools/helpers.py
@@ -58,4 +58,4 @@ def encode(num, alphabet=BASE62):
 
 def create_iso8601_tz():
     ret = datetime.now(timezone.utc).isoformat()[:-13]+'Z'
-    return ret.isoformat()
+    return ret


### PR DESCRIPTION
ret is a sting and don't need to use isoformat again.